### PR TITLE
fix: update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -54,7 +54,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.archive_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.archive_name }}
           path: ${{ matrix.archive_name }}
@@ -67,10 +67,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -82,11 +82,10 @@ jobs:
           ls -la release/
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: release/*
           generate_release_notes: true
           make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -34,35 +34,35 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "c_linked_list"
@@ -72,15 +72,15 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -100,18 +100,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
+checksum = "8e602857739c5a4291dfa33b5a298aeac9006185229a700e5810a3ef7272d971"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -121,15 +121,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc33c849748320656a90832f54a5eeecaa598e92557fb5dedebc3355746d31e4"
+checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
 dependencies = [
  "clap",
  "roff",
@@ -143,14 +143,14 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "dns-lookup"
-version = "2.0.4"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
  "socket2",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -195,9 +195,9 @@ checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -207,36 +207,36 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -271,18 +271,28 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -291,24 +301,25 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -319,9 +330,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -330,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "utf8parse"
@@ -347,149 +358,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 get_if_addrs = "0.5"
 anyhow = "1"
-dns-lookup = "2"
+dns-lookup = "3"
 bitflags = "2"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -7,9 +7,8 @@ use std::path::PathBuf;
 include!("src/cli.rs");
 
 fn main() -> Result<(), Error> {
-    let out_dir = match std::env::var_os("OUT_DIR") {
-        None => return Ok(()),
-        Some(out_dir) => out_dir,
+    let Some(out_dir) = std::env::var_os("OUT_DIR") else {
+        return Ok(());
     };
 
     let mut cmd = build_cli();

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -10,9 +10,10 @@ pub struct ResolvedAddress {
 
 pub fn resolve_hostname(hostname: &str) -> Result<ResolvedAddress> {
     match lookup_host(hostname) {
-        Ok(addresses) => {
+        Ok(address_iter) => {
+            let addresses: Vec<IpAddr> = address_iter.collect();
             if addresses.is_empty() {
-                Err(anyhow!("No addresses found for hostname '{}'", hostname))
+                Err(anyhow!("No addresses found for hostname '{hostname}'"))
             } else {
                 Ok(ResolvedAddress {
                     hostname: hostname.to_string(),
@@ -20,7 +21,7 @@ pub fn resolve_hostname(hostname: &str) -> Result<ResolvedAddress> {
                 })
             }
         }
-        Err(e) => Err(anyhow!("DNS lookup failed for '{}': {}", hostname, e)),
+        Err(e) => Err(anyhow!("DNS lookup failed for '{hostname}': {e}")),
     }
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -33,14 +33,11 @@ pub fn get_interface_info(interface_name: &str) -> Result<InterfaceInfo> {
     }
 
     if !found {
-        return Err(anyhow!("Interface '{}' not found", interface_name));
+        return Err(anyhow!("Interface '{interface_name}' not found"));
     }
 
     if ipv4_addresses.is_empty() && ipv6_addresses.is_empty() {
-        return Err(anyhow!(
-            "No IP addresses found on interface '{}'",
-            interface_name
-        ));
+        return Err(anyhow!("No IP addresses found on interface '{interface_name}'"));
     }
 
     Ok(InterfaceInfo {
@@ -84,11 +81,11 @@ mod tests {
     #[test]
     fn test_netmask_to_prefix_v4() {
         // Test common IPv4 netmasks
-        assert_eq!(netmask_to_prefix_v4(Ipv4Addr::new(255, 255, 255, 255)), 32);
+        assert_eq!(netmask_to_prefix_v4(Ipv4Addr::BROADCAST), 32);
         assert_eq!(netmask_to_prefix_v4(Ipv4Addr::new(255, 255, 255, 0)), 24);
         assert_eq!(netmask_to_prefix_v4(Ipv4Addr::new(255, 255, 0, 0)), 16);
         assert_eq!(netmask_to_prefix_v4(Ipv4Addr::new(255, 0, 0, 0)), 8);
-        assert_eq!(netmask_to_prefix_v4(Ipv4Addr::new(0, 0, 0, 0)), 0);
+        assert_eq!(netmask_to_prefix_v4(Ipv4Addr::UNSPECIFIED), 0);
 
         // Test some less common netmasks
         assert_eq!(netmask_to_prefix_v4(Ipv4Addr::new(255, 255, 255, 128)), 25);

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -126,7 +126,7 @@ impl IPv4Calculator {
 
     fn prefix_to_netmask(prefix_length: u8) -> Ipv4Addr {
         if prefix_length == 0 {
-            return Ipv4Addr::new(0, 0, 0, 0);
+            return Ipv4Addr::UNSPECIFIED;
         }
 
         let mask = (!0u32) << (32 - prefix_length);
@@ -532,8 +532,8 @@ mod tests {
     fn test_ipv4_edge_cases() {
         // Test /0 network
         let calc = IPv4Calculator::new("0.0.0.0/0").unwrap();
-        assert_eq!(calc.network, Ipv4Addr::new(0, 0, 0, 0));
-        assert_eq!(calc.broadcast, Ipv4Addr::new(255, 255, 255, 255));
+        assert_eq!(calc.network, Ipv4Addr::UNSPECIFIED);
+        assert_eq!(calc.broadcast, Ipv4Addr::BROADCAST);
         assert_eq!(calc.get_host_count(), 4_294_967_296);
 
         // Test /30 network (common for point-to-point)

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -143,7 +143,7 @@ impl IPv6Calculator {
 
     fn calculate_network(address: Ipv6Addr, prefix_length: u8) -> Ipv6Addr {
         if prefix_length == 0 {
-            return Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+            return Ipv6Addr::UNSPECIFIED;
         }
 
         let addr_bytes = address.octets();
@@ -559,10 +559,7 @@ impl IPv6Calculator {
         let subnet_count = 2u128.pow(u32::from(additional_bits));
         // For very large numbers of subnets, enforce threshold to satisfy unit tests
         if subnet_count > 10000 {
-            return Err(anyhow!(
-                "Too many subnets to generate ({} subnets)",
-                subnet_count
-            ));
+            return Err(anyhow!("Too many subnets to generate ({subnet_count} subnets)"));
         }
 
         let mut subnets = Vec::new();

--- a/src/output.rs
+++ b/src/output.rs
@@ -368,59 +368,58 @@ impl OutputFormatter {
     }
 
     fn format_ipv4_split_section(calc: &IPv4Calculator, config: &Config) {
-        if let Some(ref split_mask) = config.split_ipv4 {
-            if let Ok(new_prefix) = Self::parse_ipv4_mask_to_prefix(split_mask) {
-                if let Ok(subnets) = calc.split_network(new_prefix) {
-                    if config.output.split_verbose {
-                        // Verbose split mode - show information for each subnet (matches sipcalc)
-                        println!("[Split network - verbose]");
-                        for subnet in &subnets {
-                            // Show header for each subnet with original network (matches sipcalc format)
-                            println!(
-                                "-[ipv4 : {}/{prefix}] - 0",
-                                calc.network,
-                                prefix = calc.prefix_length
-                            );
-                            println!();
+        if let Some(split_mask) = &config.split_ipv4
+            && let Ok(new_prefix) = Self::parse_ipv4_mask_to_prefix(split_mask)
+            && let Ok(subnets) = calc.split_network(new_prefix)
+        {
+            if config.output.split_verbose {
+                // Verbose split mode - show information for each subnet (matches sipcalc)
+                println!("[Split network - verbose]");
+                for subnet in &subnets {
+                    // Show header for each subnet with original network (matches sipcalc format)
+                    println!(
+                        "-[ipv4 : {}/{prefix}] - 0",
+                        calc.network,
+                        prefix = calc.prefix_length
+                    );
+                    println!();
 
-                            if config.output.all_info {
-                                // With -a flag: show full information for each subnet
-                                // Show classful section with hybrid info (subnet host, original classful)
-                                Self::format_ipv4_classful_section_for_split(subnet, calc);
-                                println!();
+                    if config.output.all_info {
+                        // With -a flag: show full information for each subnet
+                        // Show classful section with hybrid info (subnet host, original classful)
+                        Self::format_ipv4_classful_section_for_split(subnet, calc);
+                        println!();
 
-                                // Show CIDR section for the split subnet
-                                Self::format_ipv4_cidr_section(subnet);
-                                println!();
+                        // Show CIDR section for the split subnet
+                        Self::format_ipv4_cidr_section(subnet);
+                        println!();
 
-                                // Show classful bitmaps section using original network
-                                Self::format_ipv4_classful_bitmap_section(calc);
-                                println!();
+                        // Show classful bitmaps section using original network
+                        Self::format_ipv4_classful_bitmap_section(calc);
+                        println!();
 
-                                // Show CIDR bitmaps section for the split subnet
-                                Self::format_ipv4_cidr_bitmap_section(subnet);
-                                println!();
+                        // Show CIDR bitmaps section for the split subnet
+                        Self::format_ipv4_cidr_bitmap_section(subnet);
+                        println!();
 
-                                // Show networks section for the split subnet
-                                Self::format_ipv4_networks_section(subnet);
-                            } else {
-                                // Without -a flag: show only CIDR section for each subnet (sipcalc behavior)
-                                Self::format_ipv4_cidr_section(subnet);
-                            }
-                            println!();
-                            println!("-");
-                        }
+                        // Show networks section for the split subnet
+                        Self::format_ipv4_networks_section(subnet);
                     } else {
-                        // Normal split mode - show summary
-                        println!("[Split network]");
-                        for subnet in &subnets {
-                            // Print each subnet network and its broadcast address
-                            println!(
-                                "Network\t\t\t- {:<15} - {}",
-                                subnet.network, subnet.broadcast
-                            );
-                        }
+                        // Without -a flag: show only CIDR section for each subnet (sipcalc behavior)
+                        Self::format_ipv4_cidr_section(subnet);
                     }
+                    println!();
+                    println!("-");
+                }
+            } else {
+                // Normal split mode - show summary
+                println!("[Split network]");
+                for subnet in &subnets {
+                    // Print each subnet network and its broadcast address
+                    println!(
+                        "Network\t\t\t- {:<15} - {}",
+                        subnet.network, subnet.broadcast
+                    );
                 }
             }
         }
@@ -857,26 +856,25 @@ impl OutputFormatter {
             });
         }
 
-        if let Some(ref split_mask) = config.split_ipv4 {
-            if let Ok(new_prefix) = Self::parse_ipv4_mask_to_prefix(split_mask) {
-                if let Ok(subnets) = calc.split_network(new_prefix) {
-                    let subnet_data: Vec<Value> = subnets
-                        .iter()
-                        .map(|subnet| {
-                            json!({
-                                "network": subnet.network.to_string(),
-                                "prefix_length": subnet.prefix_length,
-                                "broadcast": subnet.broadcast.to_string(),
-                                "usable_range": {
-                                    "start": subnet.get_first_usable().to_string(),
-                                    "end": subnet.get_last_usable().to_string()
-                                }
-                            })
-                        })
-                        .collect();
-                    result["subnets"] = json!(subnet_data);
-                }
-            }
+        if let Some(split_mask) = &config.split_ipv4
+            && let Ok(new_prefix) = Self::parse_ipv4_mask_to_prefix(split_mask)
+            && let Ok(subnets) = calc.split_network(new_prefix)
+        {
+            let subnet_data: Vec<Value> = subnets
+                .iter()
+                .map(|subnet| {
+                    json!({
+                        "network": subnet.network.to_string(),
+                        "prefix_length": subnet.prefix_length,
+                        "broadcast": subnet.broadcast.to_string(),
+                        "usable_range": {
+                            "start": subnet.get_first_usable().to_string(),
+                            "end": subnet.get_last_usable().to_string()
+                        }
+                    })
+                })
+                .collect();
+            result["subnets"] = json!(subnet_data);
         }
 
         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -911,28 +909,27 @@ impl OutputFormatter {
             });
         }
 
-        if let Some(ref split_prefix) = config.split_ipv6 {
-            if let Ok(new_prefix) = split_prefix.parse::<u8>() {
-                if let Ok(subnets) = calc.split_network(new_prefix) {
-                    let subnet_data: Vec<Value> = subnets
-                        .iter()
-                        .map(|subnet| {
-                            let (start, end) = subnet.get_network_range();
-                            json!({
-                                "network": subnet.network.to_string(),
-                                "prefix_length": subnet.prefix_length,
-                                "expanded_address": subnet.get_expanded_address(),
-                                "compressed_address": subnet.get_compressed_address(),
-                                "network_range": {
-                                    "start": start.to_string(),
-                                    "end": end.to_string()
-                                }
-                            })
-                        })
-                        .collect();
-                    result["subnets"] = json!(subnet_data);
-                }
-            }
+        if let Some(split_prefix) = &config.split_ipv6
+            && let Ok(new_prefix) = split_prefix.parse::<u8>()
+            && let Ok(subnets) = calc.split_network(new_prefix)
+        {
+            let subnet_data: Vec<Value> = subnets
+                .iter()
+                .map(|subnet| {
+                    let (start, end) = subnet.get_network_range();
+                    json!({
+                        "network": subnet.network.to_string(),
+                        "prefix_length": subnet.prefix_length,
+                        "expanded_address": subnet.get_expanded_address(),
+                        "compressed_address": subnet.get_compressed_address(),
+                        "network_range": {
+                            "start": start.to_string(),
+                            "end": end.to_string()
+                        }
+                    })
+                })
+                .collect();
+            result["subnets"] = json!(subnet_data);
         }
 
         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -940,10 +937,10 @@ impl OutputFormatter {
     }
 
     fn parse_ipv4_mask_to_prefix(mask_str: &str) -> Result<u8> {
-        if let Ok(prefix) = mask_str.parse::<u8>() {
-            if prefix <= 32 {
-                return Ok(prefix);
-            }
+        if let Ok(prefix) = mask_str.parse::<u8>()
+            && prefix <= 32
+        {
+            return Ok(prefix);
         }
 
         if mask_str.starts_with("0x") || mask_str.starts_with("0X") {


### PR DESCRIPTION
## Summary
- bump clap, serde, dns-lookup, etc. to resolve Dependabot alerts
- regenerate cargo lockfile and update release CI actions to v5/v6
- fix clippy regressions introduced by dns-lookup 3.x and new lint defaults

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings -W clippy::pedantic -W clippy::nursery
- cargo test