### PR TITLE
chore: roll up dependabot updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.archive_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.archive_name }}
           path: ${{ matrix.archive_name }}
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.61"
+version = "4.5.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
+checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
 dependencies = [
  "clap",
 ]

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -37,7 +37,9 @@ pub fn get_interface_info(interface_name: &str) -> Result<InterfaceInfo> {
     }
 
     if ipv4_addresses.is_empty() && ipv6_addresses.is_empty() {
-        return Err(anyhow!("No IP addresses found on interface '{interface_name}'"));
+        return Err(anyhow!(
+            "No IP addresses found on interface '{interface_name}'"
+        ));
     }
 
     Ok(InterfaceInfo {

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -559,7 +559,9 @@ impl IPv6Calculator {
         let subnet_count = 2u128.pow(u32::from(additional_bits));
         // For very large numbers of subnets, enforce threshold to satisfy unit tests
         if subnet_count > 10000 {
-            return Err(anyhow!("Too many subnets to generate ({subnet_count} subnets)"));
+            return Err(anyhow!(
+                "Too many subnets to generate ({subnet_count} subnets)"
+            ));
         }
 
         let mut subnets = Vec::new();


### PR DESCRIPTION
Rolls up Dependabot PRs #23, #24, and #25 into a single update.