### PR TITLE
ci: fix github-actions dependabot cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-minor-days: 7
-      semver-major-days: 30
     groups:
       all-version-updates:
         patterns:


### PR DESCRIPTION
## Summary
- remove unsupported `semver-minor-days` and `semver-major-days` from the `github-actions` Dependabot cooldown block
- keep `default-days: 7` so the config still satisfies Zizmor's cooldown audit

## Validation
- scanned the local `.github/dependabot.yml` to confirm no unsupported `github-actions` cooldown keys remain
